### PR TITLE
Add auto-gloss on page load, fix about link, update outdated gloss

### DIFF
--- a/index.html
+++ b/index.html
@@ -506,6 +506,7 @@ function update_txt2(text) {
   }
   return txt2.textContent = text;
 }
+update_txt2();
 </script>
     </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -313,7 +313,7 @@
     </head>
     <body id="poki">
         <img id="logo" src="logo.svg" alt=""><h1>telo misikeke fork: TOKI PONA GLOSS TOOL</a></h1>
-        <h2 id="subtitle">o alasa e pakala! <small><a href="README.md">[About]</a></small></h2>
+        <h2 id="subtitle">o alasa e pakala! <small><a href="about.html">[About]</a></small></h2>
         <p id="options">
             <label><input id="useLinebreaks" type="checkbox" onclick="reloadWithOptions()"> Line breaks form new sentences</label><br>
             <label><input id="ignore-nitpick" type="checkbox" onclick="reloadWithOptions()"> Don't show

--- a/index.html
+++ b/index.html
@@ -371,7 +371,7 @@ e ilo pona mi pi nasin pona la, o kepeken ona lon tenpo pi wile sina a!
 </textarea>
         </div>
         <!-- <button  onclick="update_txt2(txt.textContent)">Gloss to English</button> -->
-        <div id="txt2" style="width: 50%; padding-top: 1.4em; line-height: 1.4; font-size: 16px !important; font-family: monospace !important; white-space: pre;">Edit the toki pona text to produce an English gloss here...</div>
+        <div id="txt2" style="width: 50%; padding-top: 1.4em; line-height: 1.4; font-size: 16px !important; font-family: monospace !important; white-space: pre;"></div>
         </div>
 <script type="text/javascript">
 function update_txt2(text) {
@@ -441,7 +441,7 @@ function update_txt2(text) {
     ["musi", "fun"],
     ["mute", "many"],
     ["nanpa", "number"],
-    ["nasa", "crazy"],
+    ["nasa", "silly"],
     ["nasin", "way"],
     ["nena", "bump"],
     ["ni", "this"],
@@ -506,7 +506,7 @@ function update_txt2(text) {
   }
   return txt2.textContent = text;
 }
-update_txt2();
+update_txt2(document.getElementById("txt").innerHTML);
 </script>
     </body>
 </html>


### PR DESCRIPTION
I've made it gloss automatically on page load, without having to wait for an edit.
The about link has been updated to send to `about.html` instead of `README.md`, which only gets downloaded as a file. I would suggest, though, editing the about page in accordance to your fork's functionality, before publishing.
The outdated meaning was "crazy" for "nasa", which I've replaced with "silly".